### PR TITLE
Google analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,7 @@ analytics: UA-332815-90
 
 # Build settings
 markdown: kramdown
-remote_theme: ncar/koru-jekyll@1.0.26
+remote_theme: ncar/koru-jekyll@1.0.27
 plugins:
   - jekyll-feed
   - jekyll-remote-theme

--- a/_config.yml
+++ b/_config.yml
@@ -22,10 +22,11 @@ description: >- # this means to ignore newlines until "baseurl:"
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 github_username:  hallock
+analytics: UA-332815-90
 
 # Build settings
 markdown: kramdown
-remote_theme: ncar/koru-jekyll@1.0.24
+remote_theme: ncar/koru-jekyll@1.0.26
 plugins:
   - jekyll-feed
   - jekyll-remote-theme


### PR DESCRIPTION
Added variable to enable google analytics, and bumped koru version to 1.0.27.

Analytics may be found here:
https://analytics.google.com/analytics/web/#/report-home/a332815w49095733p49571990

Read permissions may be currently pending for the GeoCAT team. 