### PR TITLE
Updates to embed youtube GeoCAT video on homepage

### DIFF
--- a/_includes/youtubePlayer.html
+++ b/_includes/youtubePlayer.html
@@ -1,0 +1,10 @@
+<div class="embed-container">
+  <iframe
+      src="https://www.youtube.com/embed/{{ include.id }}"
+      width="700"
+      height="480"
+      frameborder="0"
+      allowfullscreen="">
+  </iframe>
+</div>
+ 

--- a/_includes/youtubePlayer.html
+++ b/_includes/youtubePlayer.html
@@ -1,6 +1,6 @@
 <div class="embed-container">
   <iframe
-      src="https://www.youtube.com/embed/{{ include.id }}"
+      src="https://www.youtube.com/embed/34zFGkDwJPc"
       width="700"
       height="480"
       frameborder="0"

--- a/index.md
+++ b/index.md
@@ -4,6 +4,7 @@ title: Home
 banner-title: <img src='/images/GeoCAT_Final_Logos-02.svg' style="margin:-10% 0px -7% 0px;" width=500 />
 banner-button-text: GeoCAT Software
 banner-button-url: /pages/software.html
+youtubeID: 34zFGkDwJPc
 ---
 
 # Welcome
@@ -13,3 +14,5 @@ banner-button-url: /pages/software.html
 GeoCAT is a product of the **National Center for Atmospheric Research's Computational and Information Systems Lab**. Support for GeoCAT is provided by the U.S. **National Science Foundation**.
 
 Visit the [GeoCAT Development Blog](blog) to read about our latest development progress.
+
+{% include youtubePlayer.html id=page.youtubeId %}

--- a/index.md
+++ b/index.md
@@ -15,4 +15,4 @@ GeoCAT is a product of the **National Center for Atmospheric Research's Computat
 
 Visit the [GeoCAT Development Blog](blog) to read about our latest development progress.
 
-{% include youtubePlayer.html id=page.youtubeId %}
+{% include youtubePlayer.html %}


### PR DESCRIPTION
I have not been able to get the docker container to build locally. Through extensive troubleshooting, I learned it may be resulting from a file or path that has been corrupted that is one of the dependancies to build the container locally. Please try to build this locally before approving any changes!

For further info: I was using the tutorial from this repo https://github.com/nathancy/jekyll-embed-video on how to embed a youtube video to a GitHub pages website. 