### PR TITLE
NCAR channel dropped support announcement

### DIFF
--- a/blog/_posts/2022-08-09-ncar-channel-update.md
+++ b/blog/_posts/2022-08-09-ncar-channel-update.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title: "Important Update About Conda Releases"
+description: ""
+tags: []
+---
+{% include JB/setup %}
+
+Dear GeoCAT users,
+
+We would like to make an important announcement about our Conda releases 
+of GeoCAT software packages:
+
+The GeoCAT team has moved the Conda releases of several software tools 
+(listed below) from the "NCAR" channel to the "conda-forge" channel only, 
+effective after the v2022.07.* versions. From now on, please be sure to 
+install GeoCAT tools from conda-forge for the latest version. For 
+reproducibility purposes however, the older versions at the NCAR channel 
+will still be accessible.
+
+The GeoCAT Team - CISL/NCAR
+August 9, 2022 


### PR DESCRIPTION
Makes an announcement about we dropped NCAR channel support for Conda release distributions and will only release at the conda-forge channel from August.