### PR TITLE
Start using Accessibility link in the footer by bumping koru-jekyll theme version from 1.0.27 to 1.0.41

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ analytics: UA-332815-90
 
 # Build settings
 markdown: kramdown
-remote_theme: ncar/koru-jekyll@1.0.27
+remote_theme: ncar/koru-jekyll@1.0.41
 plugins:
   - jekyll-feed
   - jekyll-remote-theme


### PR DESCRIPTION
Closes #67

Start using version 1.0.41 of koru-jekyll. 

This is essentially for getting the #67 addressed, but may also add other features happened in between the older and newer versions.