### PR TITLE
Update _config.yml to use the newer ncar-jekyll theme for branding updates

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ analytics: UA-332815-90
 
 # Build settings
 markdown: kramdown
-remote_theme: ncar/koru-jekyll@1.0.41
+remote_theme: ncar/koru-jekyll@1.0.42
 plugins:
   - jekyll-feed
   - jekyll-remote-theme


### PR DESCRIPTION
v1.0.42 of ncar-koru-jekyll is just out and has the newest NSF NCAR logo (Re https://github.com/NCAR/koru-jekyll/issues/16#issuecomment-1936709823)